### PR TITLE
holoviews 1.15.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - ipython >=5.4.0
     - notebook
     # Recommended dependencies: IPython Notebook + pandas + matplotlib + bokeh
+    # It seems it seems holoviews isn't compatible with bokeh >=3.0.0
     - bokeh >=2.4.3,<3.0
     - matplotlib-base >=3
 
@@ -61,7 +62,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
-  dev_url: https://github.com/ioam/holoviews
+  dev_url: https://github.com/holoviz/holoviews
   doc_url: https://holoviews.org/getting_started/index.html
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
     - pip
     - pyct
-    - param <2.0
+    - param
     - setuptools
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - ipython >=5.4.0
     - notebook
     # Recommended dependencies: IPython Notebook + pandas + matplotlib + bokeh
-    # It seems it seems holoviews isn't compatible with bokeh >=3.0.0
+    # It seems holoviews isn't compatible with bokeh >=3.0.0
     - bokeh >=2.4.3,<3.0
     - matplotlib-base >=3
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "holoviews" %}
-{% set version = "1.15.0" %}
+{% set version = "1.15.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/holoviews-{{ version }}.tar.gz
-  sha256: 312e60d24406c3a7aec46261836b38dba2585e366bccb45e47479504805eb5ba
+  sha256: dec2417f654008b1d7b645b31ecf621c8bef901694e4c4e7272effd18afa36db
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  # trigger: 1
   # We cannot build a recent version of panel due to missing nodejs on s390x
   skip: True  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
@@ -22,14 +21,15 @@ requirements:
   host:
     - python
     - pip
-    - pyct >=0.4.4
-    - param >=1.9.3
-    - setuptools >=30.3.0
+    - pyct
+    - param <2.0
+    - setuptools
     - wheel
   run:
     - python
     - colorcet
     - numpy >=1.0
+    - packaging
     - panel >=0.13.1
     - pandas >=0.20.0
     - param >=1.9.3,<2.0
@@ -38,7 +38,7 @@ requirements:
     - ipython >=5.4.0
     - notebook
     # Recommended dependencies: IPython Notebook + pandas + matplotlib + bokeh
-    - bokeh >=2.4.3
+    - bokeh >=2.4.3,<3.0
     - matplotlib-base >=3
 
 test:


### PR DESCRIPTION
**Jira ticket:** [PKG-725](https://anaconda.atlassian.net/browse/PKG-725) (holoviews-1.15.2)

**The upstream data:**
Github releases:  https://github.com/ioam/holoviews/releases
[Diff between the latest and previous upstream releases](https://github.com/holoviz/holoviews/compare/v1.15.0...v1.15.2)
Changelog: https://github.com/ioam/holoviews/blob/master/CHANGELOG.md
Requirements:
 * setup.py:  https://github.com/ioam/holoviews/blob/v1.15.2/setup.py
 *  pyproject.toml:  https://github.com/ioam/holoviews/blob/v1.15.2/pyproject.toml

**_Actions:_**

1. Remove pinnings from `host`.
2. Add pinning for `param`
3. Add `packaging` to `run`
4. Fix `bokeh` pinning because versions `>= 3.0.0` have breaking changes 

**Package's statistics**
<details>

 * Priority B | effort: easy | Category: anaconda_affiliated | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 1.15.2
 * Release on PyPi:
    * version: 1.15.2
    * date: 2022-11-03T13:35:06
* [PyPi history](https://pypi.org/project/holoviews/#history)
 * Popularity: 
    * 3 months downloads: 348828.0
    * All time:  965065 downloads -  holoviews  1.15.2  Stop plotting your data - annotate your data and let it visualize itself.  

</details>

**Other checks:**

<details>

5. - [x] https://holoviews.org is present
6. - [x] Check the pinnings
8. - [x] Additional research
    https://github.com/holoviz/holoviews/issues
9. - [x] `dev_url`:
    https://github.com/holoviz/holoviews
10. - [x] `doc_url` is present
    https://holoviews.org/getting_started/index.html
11. - [x] Verify that the `build_number` is correct
12. - [x] has `setuptools`
13. - [x] has `wheel`
14. - [x] `pip` in test
15. - [x] Verify the test section
16. - [x] Verify if the package is `architecture specific`
17. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
18.  - [x] license_file: LICENSE.txt is present
19. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

20. - [x] license_family BSD is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/holoviews-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/holoviews-feedstock/tree/1.15.2)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/holoviews)
* [Diff between upstream and feature branch](https://github.com/conda-forge/holoviews-feedstock/compare/main...AnacondaRecipes:1.15.2)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/holoviews-feedstock/compare/master...AnacondaRecipes:1.15.2)
* [The last merged PRs](https://github.com/AnacondaRecipes/holoviews-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 1.15.2 git@github.com:AnacondaRecipes/holoviews-feedstock.git
```
