### PR TITLE
Update to 1.17.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "holoviews" %}
-{% set version = "1.16.2" %}
+{% set version = "1.17.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 45c568ae57a43af73893a093e6fade96b7713cbb0fe6fff46426a6b613122746
+  sha256: 4ae71f923557165b886cde2acc4d4d4b222d3d8db3b34cf2772210fe456c7452
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   # We cannot build a recent version of panel due to missing nodejs and panel on s390x
-  skip: True  # [py<37 or s390x]
+  skip: True  # [py<38 or s390x]
   entry_points:
     - holoviews = holoviews.util.command:main
   script:


### PR DESCRIPTION
Simple version bump to 1.17.0 - I simply followed the changes in the conda-forge feedstock.