### PR TITLE
Bump version to 1.18.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "holoviews" %}
-{% set version = "1.17.1" %}
+{% set version = "1.18.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ca30c661508b22e9e8c119dbc3e4a5d851987b43c30565db180b291d8fd770a4
+  sha256: bab72961ab7a18794db269351d905523f2aadcad593b321512927ce93dc9df91
 
 build:
   number: 0
   # We cannot build a recent version of panel due to missing nodejs and panel on s390x
-  skip: True  # [py<38 or s390x]
+  skip: True  # [py<39 or s390x]
   entry_points:
     - holoviews = holoviews.util.command:main
   script:
@@ -22,16 +22,16 @@ requirements:
   host:
     - python
     - pip
-    - pyct
-    - param
     - setuptools
     - wheel
+    - pyct 0.5.0
+    - param 2.0.0
   run:
     - python
     - colorcet
     - numpy >=1.0
     - packaging
-    - panel >=0.13.1
+    - panel >=1.0
     - pandas >=0.20.0
     - param >=1.12.0,<3.0
     - pyviz_comms >=0.7.4


### PR DESCRIPTION
Bumps the version, minimum required Python and Panel and introduces precise pins for build deps.