### PR TITLE
HoloViews 1.19.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,8 @@ requirements:
     - panel >=1.0
     - param >=2.0,<3.0
     - pyviz_comms >=2.1
+  run_constrained:
+    - plotly >=4.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - hatchling
     - hatch-vcs
   run:
-    - python >=3.9
+    - python
     - bokeh >=3.1
     - colorcet
     - matplotlib-base >=3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "holoviews" %}
-{% set version = "1.18.3" %}
+{% set version = "1.19.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 578e30e89d72754f97a83ebe08198fec8e87cc7e49b25b9f31ec393f939ca500
+  sha256: cab1522f75a9b46377f9364b675befd79812e220059714470a58e21475d531ba
 
 build:
   number: 0
@@ -22,20 +22,19 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
-    - pyct 0.5.0
-    - param 2.0
+    - hatchling
+    - hatch-vcs
   run:
-    - python
+    - python >=3.9
+    - bokeh >=3.1
     - colorcet
-    - numpy >=1.0
+    - matplotlib-base >=3.0
+    - numpy >=1.21
     - packaging
+    - pandas >=1.3
     - panel >=1.0
-    - pandas >=0.20.0
-    - param >=1.12.0,<3.0
-    - pyviz_comms >=0.7.4
-    - matplotlib-base >=3
+    - param >=2.0,<3.0
+    - pyviz_comms >=2.1
 
 test:
   imports:
@@ -65,6 +64,7 @@ extra:
     - jlstevens
     - philippjfr
     - basnijholt
+    - hoxbro
   skip-lints:
     - python_build_tool_in_run
     - host_section_needs_exact_pinnings


### PR DESCRIPTION
holoviews 1.19.0 

**Destination channel:** {defaults}

### Links

- [Upstream repository](https://github.com/holoviz/holoviews)
- [Upstream changelog/diff](https://github.com/holoviz/holoviews/blob/main/doc/releases.md)
- Relevant dependency PRs:
	- Update param minimum version to 2.0 (https://github.com/holoviz/holoviews/pull/6230)
    - Update numpy >=1.21, pandas >= 1.3, and Bokeh >=3.1 (https://github.com/holoviz/holoviews/pull/6253)
