### PR TITLE
Update to version 1.20.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "holoviews" %}
-{% set version = "1.20.0" %}
+{% set version = "1.20.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 29d183045fafa3d846deda999d9687b99b8abdc1a8c06712e54afa576bb02b3e
+  sha256: f4ad8c6533d9ac918a762cb6ba8e7508f55525f9dfa447b8806da66272badceb
 
 build:
   number: 0


### PR DESCRIPTION
holoviews 1.20.1

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/holoviews)
- [Upstream changelog/diff](https://github.com/holoviz/holoviews/compare/v1.20.0...v1.20.1)
