### PR TITLE
Update to 1.20.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "holoviews" %}
-{% set version = "1.20.1" %}
+{% set version = "1.20.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f4ad8c6533d9ac918a762cb6ba8e7508f55525f9dfa447b8806da66272badceb
+  sha256: 8c78b798601ce3af31523667c6d1cb40df8d781249ebebbdb2c5f6143565e6d8
 
 build:
   number: 0


### PR DESCRIPTION
holoviews 1.20.2

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/holoviz/holoviews)
- [Upstream changelog/diff](https://github.com/holoviz/holoviews/compare/v1.20.1...v1.20.2)
