### PR TITLE
holoviews 1.22.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ test:
     - holoviews.element
     - holoviews.operation
     - holoviews.plotting
+    - holoviews.plotting.mpl
     - holoviews.plotting.bokeh
     - holoviews.util
   source_files:
@@ -55,6 +56,7 @@ test:
   requires:
     - pip
     - pytest
+    - scipy
   commands:
     - pip check
     - holoviews -h

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,9 +35,9 @@ requirements:
     - pyviz_comms >=2.1
     - narwhals >=2
     - python-dateutil >=2.8.2
+    - matplotlib-base >=3
   run_constrained:
     - plotly >=4.0
-    - matplotlib-base >=3
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,17 @@
 {% set name = "holoviews" %}
-{% set version = "1.21.0" %}
+{% set version = "1.22.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 837885ab2fa376677f21dae0b2a2aeb94ba6db96e9fcb3824cdb899538ee5032
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 2bd3eb5ef5062b893a56c4c42077a3ed92314a92f378d2bc77c75e017b86edba
 
 build:
   number: 0
-  # We cannot build a recent version of panel due to missing nodejs and panel on s390x
-  skip: True  # [py<310]
+  skip: true  # [py<310]
   entry_points:
     - holoviews = holoviews.util.command:main
   script:
@@ -28,24 +27,38 @@ requirements:
     - python
     - bokeh >=3.1
     - colorcet
-    - matplotlib-base >=3.0
     - numpy >=1.21
     - packaging
     - pandas >=1.3
     - panel >=1.0
     - param >=2.0,<3.0
     - pyviz_comms >=2.1
+    - narwhals >=2
+    - python-dateutil >=2.8.2
   run_constrained:
     - plotly >=4.0
+    - matplotlib-base >=3
 
 test:
   imports:
     - holoviews
+    - holoviews.core
+    - holoviews.core.data
+    - holoviews.core.util
+    - holoviews.element
+    - holoviews.operation
+    - holoviews.plotting
+    - holoviews.plotting.bokeh
+    - holoviews.util
+  source_files:
+    - holoviews/tests
   requires:
     - pip
+    - pytest
   commands:
     - pip check
     - holoviews -h
+    - pytest --pyargs holoviews.tests
 
 about:
   home: https://holoviews.org


### PR DESCRIPTION
holoviews 1.22.0 

**Destination channel:** Defaults

### Links

- [PKG-10737]
- dev_url:        https://github.com/holoviz/holoviews/tree/v1.22.0
- conda_forge:    https://github.com/conda-forge/holoviews-feedstock
- pypi:           https://pypi.org/project/holoviews/1.22.0
- pypi inspector: https://inspector.pypi.io/project/holoviews/1.22.0

### Explanation of changes:

- new version number
- add testing

**NOTE:** No py314 build since it would require to rebuild other dependencies


[PKG-10737]: https://anaconda.atlassian.net/browse/PKG-10737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ